### PR TITLE
Document local deployment and the released OpenWhispr integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Use Orukeet for recordings, media, batch transcription, server workers and inter
 
 [Model card](MODEL_CARD.md) · [Weights](https://huggingface.co/oruk/orukeet) · [Technical report](output/pdf/orukeet-technical-report.pdf)
 
+## Use Orukeet in a desktop app
+
+[OpenWhispr 1.10.0](https://github.com/OpenWhispr/openwhispr/releases/tag/v1.10.0)
+ships Orukeet as its recommended local model. In the local model picker, choose
+**Oruk → Orukeet** and download the model. This integration uses the ONNX export
+through OpenWhispr’s existing sherpa-onnx runtime.
+
 ## Run speech recognition
 
 [Follow the local deployment tutorial](https://oruk.ai/guides/orukeet-local-transcription) for a fresh Python environment, a supplied recording, actual output and a reusable file runner. The tutorial includes the tested package version and artifact hashes.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Use Orukeet for recordings, media, batch transcription, server workers and inter
 
 ## Run speech recognition
 
+[Follow the local deployment tutorial](https://oruk.ai/guides/orukeet-local-transcription) for a fresh Python environment, a supplied recording, actual output and a reusable file runner. The tutorial includes the tested package version and artifact hashes.
+
 Use Python 3.12+ in an activated virtual environment. Install the prebuilt
 v0.1.1 package and download its verified model and native runtime:
 


### PR DESCRIPTION
Add two concrete ways to use the released model: the verified Python deployment tutorial and OpenWhispr 1.10.0, which names Orukeet its recommended local recognizer. Link the official app release and explain which export it uses.

The tutorial includes a supplied audio file, actual native Q8 output, installation hashes and a reusable worker. Its fresh v0.1.1 installation and transcription checks passed. No model or runtime code changes.

Merge after https://oruk.ai/guides/orukeet-local-transcription is live.
