### PR TITLE
Verify ONNX downloads through the Hugging Face manifest

### DIFF
--- a/MODEL_CARD.md
+++ b/MODEL_CARD.md
@@ -79,6 +79,9 @@ The API returns transcript text and segment times. Language detection, diarizati
 
 The [ONNX INT8 archive](https://huggingface.co/oruk/orukeet/resolve/55a984d46f68323301837194ce647c702f55facc/onnx/sherpa-onnx-orukeet-v0.1.0-int8.tar.bz2) uses the standard Parakeet TDT v3 layout: `encoder.int8.onnx`, `decoder.int8.onnx`, `joiner.int8.onnx` and `tokens.txt`. It also includes the BPE vocabulary, weight license and attribution. Gabor filters are ordinary convolution weights; the model uses sherpa-onnx's existing offline transducer loader.
 
+Use the [verified download quickstart](README.md#sherpa-onnx-inference) to fetch
+the archive and its checksum manifest from Hugging Face, with offline cache reuse.
+
 The optimized encoder evaluates 24 quantized depthwise convolutions with exactly equivalent FP32 arithmetic using operators already in ONNX Runtime. All 640 application-check transcripts match the previous export; the same 160-clip timing sample has a 390 ms median versus 432 ms before optimization and 428 ms for stock Parakeet on M5 Max. [Execution details and receipts](evidence/speed20260910/README.md).
 
 The OpenWhispr PR uses this format through its existing Parakeet worker. Choose **Local → Oruk → Orukeet**, then **Download**. Recognition runs locally after installation.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Automatic selection installs the **optimized Metal runtime on Apple silicon**,
 CUDA on a detected NVIDIA device, or CPU. The installer verifies the Q8 weights
 and SDK hashes. Installing the prebuilt SDK requires no CMake, Ninja or compiler.
 
+Model weights come from [oruk/orukeet on Hugging Face](https://huggingface.co/oruk/orukeet),
+at pinned revisions. GitHub hosts the Python package and native SDKs. Cached
+weights are reused, and transcription runs offline.
+
 Use the saved installation receipt to transcribe locally:
 
 ```python
@@ -127,6 +131,19 @@ Gabor recovery uses transducer loss, encoder matching and token/duration distill
 [Fit and freeze recipe](training/gabor_half/README.md) · [Final adaptation](training/librispeech_ft/README.md) · [Training lineage](training/README.md)
 
 ## sherpa-onnx inference
+
+From this repository checkout, download the pinned archive and its verification
+manifest from Hugging Face:
+
+```sh
+python -m pip install "huggingface-hub>=0.34,<2"
+python examples/download_onnx.py --cache ./orukeet-cache
+tar -xjf ./orukeet-cache/models/onnx/sherpa-onnx-orukeet-v0.1.0-int8.tar.bz2
+```
+
+The downloader verifies the manifest's SHA-256, then checks the archive's size
+and SHA-256 against it. Repeat runs reuse the Hub cache; add `--local-files-only`
+for an offline check. [Download sources and counting](docs/usage.md#download-sources-and-counting).
 
 The [ONNX INT8 archive](https://huggingface.co/oruk/orukeet/resolve/55a984d46f68323301837194ce647c702f55facc/onnx/sherpa-onnx-orukeet-v0.1.0-int8.tar.bz2) uses the standard Parakeet TDT v3 layout: `encoder.int8.onnx`, `decoder.int8.onnx`, `joiner.int8.onnx` and `tokens.txt`. It also includes the BPE vocabulary, weight license and attribution. Gabor filters are ordinary convolution weights; the model uses sherpa-onnx's existing offline transducer loader.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -110,3 +110,23 @@ export; start adaptation from the source checkpoint in the NeMo stack.
 ## Model and format measurements
 
 All current downloads derive from r3. The [model card](../MODEL_CARD.md) and [report](technical-report.md) describe the source and native measurements, language set and input/output behavior.
+
+## Download sources and counting
+
+All released weights are hosted by [oruk/orukeet on Hugging Face](https://huggingface.co/oruk/orukeet).
+The native installer and `orukeet fetch source`, `orukeet fetch q8`, and
+`orukeet fetch f16` use `hf_hub_download` with pinned revisions and SHA-256 checks.
+GitHub supplies the Python package and native SDK, which contain no model weights.
+
+For ONNX, use [the repository downloader](../examples/download_onnx.py) as shown
+in the [quickstart](../README.md#sherpa-onnx-inference). It downloads the pinned
+`onnx/manifest.json` and uses it to verify the archive. The manifest also provides
+hashes for each extracted file.
+
+[Hugging Face counts downloads on its servers](https://huggingface.co/docs/hub/models-download-stats).
+GGUF downloads are counted directly; the repository's NeMo library metadata
+counts `.nemo` and `.json` files, including the ONNX manifest. A direct ONNX
+archive download without that manifest is not covered by these published rules.
+Repository clones and Python package installs alone are not model downloads.
+Cached weights and offline transcription remain available without forced
+downloads or requests made only to increment a counter.

--- a/examples/download_onnx.py
+++ b/examples/download_onnx.py
@@ -1,0 +1,45 @@
+"""Download the pinned ONNX release and verify it against its Hub manifest."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+from huggingface_hub import hf_hub_download
+
+
+REPO_ID = "oruk/orukeet"
+REVISION = "55a984d46f68323301837194ce647c702f55facc"
+MANIFEST_PATH = "onnx/manifest.json"
+MANIFEST_SHA256 = "7e80f93f0e9b923c392424b0f85d28a717feee0a4d2a6aa9bfa723693868e727"
+
+
+def verify(path, expected):
+    with path.open("rb") as stream:
+        if hashlib.file_digest(stream, "sha256").hexdigest() != expected:
+            raise ValueError(f"SHA-256 mismatch: {path.name}")
+
+
+def download(cache, *, local_files_only=False):
+    options = dict(revision=REVISION, local_dir=Path(cache) / "models",
+                   local_files_only=local_files_only)
+    manifest_path = Path(hf_hub_download(REPO_ID, MANIFEST_PATH, **options))
+    verify(manifest_path, MANIFEST_SHA256)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    archive = Path(hf_hub_download(REPO_ID, "onnx/" + manifest["archive"], **options))
+    if archive.stat().st_size != manifest["archive_bytes"]:
+        raise ValueError("ONNX archive size mismatch")
+    verify(archive, manifest["archive_sha256"])
+    return archive
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cache", type=Path, default=Path.home() / ".cache/orukeet")
+    parser.add_argument("--local-files-only", action="store_true",
+                        help="Use cached files without contacting Hugging Face")
+    args = parser.parse_args()
+    print(download(args.cache, local_files_only=args.local_files_only).resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/export/onnx/README.md
+++ b/export/onnx/README.md
@@ -6,6 +6,12 @@ Orukeet's Gabor filters are stored as ordinary `Conv1d` weights. The export does
 not require a custom frontend, an Orukeet-specific ONNX operator, or a new application
 runtime.
 
+To use the released weights, run `python examples/download_onnx.py --cache
+./orukeet-cache` from the repository root after installing `huggingface-hub`.
+This downloads the pinned archive and its manifest from Hugging Face and checks
+their hashes. See the [inference quickstart](../../README.md#sherpa-onnx-inference).
+The export steps below are for rebuilding the graphs from the source checkpoint.
+
 The checkpoint is pinned to SHA-256
 `031c8ddab4845aeced904a7cde8e8aa57993b2e344716cf83a545b079c473b56`.
 Before conversion, the script checks all 12,288 selected filters against the

--- a/tests/test_hub_downloads.py
+++ b/tests/test_hub_downloads.py
@@ -1,0 +1,72 @@
+"""Verify Hub provenance and integrity without downloading model-sized fixtures."""
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location('download_onnx', ROOT / 'examples/download_onnx.py')
+downloader = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(downloader)
+
+
+@pytest.fixture
+def release(tmp_path, monkeypatch):
+    archive = tmp_path / 'fixture.tar.bz2'
+    archive.write_bytes(b'ONNX release fixture')
+    manifest = tmp_path / 'manifest.json'
+    manifest.write_text(json.dumps({
+        'archive': archive.name,
+        'archive_bytes': archive.stat().st_size,
+        'archive_sha256': hashlib.sha256(archive.read_bytes()).hexdigest(),
+    }))
+    monkeypatch.setattr(downloader, 'MANIFEST_SHA256', hashlib.sha256(manifest.read_bytes()).hexdigest())
+    calls = []
+
+    def download(repo_id, filename, **kwargs):
+        calls.append((repo_id, filename, kwargs))
+        return str(manifest if filename == 'onnx/manifest.json' else archive)
+
+    monkeypatch.setattr(downloader, 'hf_hub_download', download)
+    return manifest, archive, calls
+
+
+@pytest.mark.parametrize('offline', [False, True])
+def test_fetches_manifest_and_weights_from_same_pinned_hub_revision(release, tmp_path, offline):
+    _, archive, calls = release
+    assert downloader.download(tmp_path, local_files_only=offline) == archive
+    assert [call[:2] for call in calls] == [
+        ('oruk/orukeet', 'onnx/manifest.json'),
+        ('oruk/orukeet', 'onnx/' + archive.name),
+    ]
+    for _, _, options in calls:
+        assert options == dict(revision='55a984d46f68323301837194ce647c702f55facc',
+                               local_dir=tmp_path / 'models', local_files_only=offline)
+
+
+def test_changed_manifest_rejected_before_weight_download(release, tmp_path):
+    manifest, _, calls = release
+    manifest.write_text('{}')
+    with pytest.raises(ValueError, match='SHA-256 mismatch: manifest.json'):
+        downloader.download(tmp_path)
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize('same_size', [False, True])
+def test_damaged_archive_rejected(release, tmp_path, same_size):
+    _, archive, _ = release
+    archive.write_bytes(b'x' * (archive.stat().st_size if same_size else 3))
+    with pytest.raises(ValueError, match='SHA-256 mismatch' if same_size else 'size mismatch'):
+        downloader.download(tmp_path)
+
+
+def test_missing_offline_cache_does_not_fall_back_to_network(tmp_path, monkeypatch):
+    def missing(repo, filename, **options):
+        assert options['local_files_only'] is True
+        raise FileNotFoundError('Not cached')
+    monkeypatch.setattr(downloader, 'hf_hub_download', missing)
+    with pytest.raises(FileNotFoundError, match='Not cached'):
+        downloader.download(tmp_path, local_files_only=True)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -76,17 +76,20 @@ def test_explicit_gpu_is_not_replaced(monkeypatch):
     assert install.resolve_device('cuda') == 'cuda'
 
 
-def test_fetch_checks_exact_artifact(tmp_path, monkeypatch):
+@pytest.mark.parametrize('artifact', ['source', 'q8', 'f16'])
+def test_fetch_checks_exact_artifact(tmp_path, monkeypatch, artifact):
     import huggingface_hub
     bad = tmp_path / 'bad.gguf'
     bad.write_bytes(b'incorrect')
     def download(repo, path, **kwargs):
         assert repo == 'oruk/orukeet'
-        assert len(kwargs['revision']) == 40
+        assert kwargs['revision'] == '555136b50265a132d4cea0d35560c26fc4f657ab'
+        assert path == {'source': 'orukeet-v0.1.0.nemo', 'q8': 'orukeet-v0.1.0-q8.gguf',
+                        'f16': 'orukeet-v0.1.0-f16.gguf'}[artifact]
         return str(bad)
     monkeypatch.setattr(huggingface_hub, 'hf_hub_download', download)
     with pytest.raises(ValueError, match='size mismatch'):
-        install.fetch('q8', tmp_path)
+        install.fetch(artifact, tmp_path)
 
 
 def test_historical_training_archives_are_not_current_model_downloads(tmp_path, monkeypatch):


### PR DESCRIPTION
The native installer already fetches counted GGUF/NeMo weights from Hugging Face. The ONNX quickstart now uses a downloader that retrieves the pinned Hub manifest and uses its archive size and SHA-256 for verification. NeMo's published download-count filter includes this manifest; the archive alone is not a query file.

Keeps existing weights, installers, and inference code unchanged. Cached files are reused, with an explicit offline option.

Validation: 44 package tests passed (one optional native integration test skipped), five training utility checks passed, and package build passed. Downloaded the real 486.8 MB archive from Hugging Face, verified all seven extracted files, and transcribed the supplied recording twice with sherpa-onnx 1.13.4. Cache reuse passed with network access blocked and with huggingface-hub 0.34.0 and 1.31.0.
