### PR TITLE
Link the recorded local transcription walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ through OpenWhispr’s existing sherpa-onnx runtime.
 
 [Follow the local deployment tutorial](https://oruk.ai/guides/orukeet-local-transcription) for a fresh Python environment, a supplied recording, actual output and a reusable file runner. The tutorial includes the tested package version and artifact hashes.
 
+[Watch the 39-second recorded example](https://oruk.ai/guides/orukeet-local-transcription#watch) to hear the input and inspect the native Q8 / Metal output. The walkthrough is edited for readability; it is not a speed or accuracy benchmark.
+
 Use Python 3.12+ in an activated virtual environment. Install the prebuilt
 v0.1.1 package and download its verified model and native runtime:
 


### PR DESCRIPTION
Link model users directly to the published 39-second local transcription example. The video includes the original input audio, actual native Q8 / Metal output, captions, a text version and a recorded missing-file error. The website and media delivery were verified after deployment.

This README-only change preserves the installer, model files, licenses and benchmark claims. The linked example explicitly distinguishes its edited presentation from a speed or accuracy evaluation.